### PR TITLE
[Experimental] Optimizes the save_episode()

### DIFF
--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -16,6 +16,7 @@
 import numpy as np
 
 from lerobot.datasets.utils import load_image_as_numpy
+from typing import List
 
 
 def estimate_num_samples(
@@ -72,6 +73,19 @@ def sample_images(image_paths: list[str]) -> np.ndarray:
     return images
 
 
+def sample_images_from_arrays(image_arrays: List[np.ndarray]) -> np.ndarray:
+    """Return (N, C, H, W) uint8 from in-memory frames (HWC or CHW)."""
+    idxs = sample_indices(len(image_arrays)) if image_arrays else []
+    imgs: list[np.ndarray] = []
+    for i in idxs:
+        arr = image_arrays[i]
+        if arr.dtype != np.uint8:
+            arr = arr.astype(np.uint8, copy=False)
+        img = np.transpose(arr, (2, 0, 1)) if (arr.ndim == 3 and arr.shape[-1] == 3) else arr
+        imgs.append(auto_downsample_height_width(img))
+    return np.stack(imgs, axis=0) if imgs else np.zeros((0, 3, 1, 1), dtype=np.uint8)
+
+
 def get_feature_stats(array: np.ndarray, axis: tuple, keepdims: bool) -> dict[str, np.ndarray]:
     return {
         "min": np.min(array, axis=axis, keepdims=keepdims),
@@ -88,7 +102,11 @@ def compute_episode_stats(episode_data: dict[str, list[str] | np.ndarray], featu
         if features[key]["dtype"] == "string":
             continue  # HACK: we should receive np.arrays of strings
         elif features[key]["dtype"] in ["image", "video"]:
-            ep_ft_array = sample_images(data)  # data is a list of image paths
+            # data can be a list of file paths (default) or a list of in-memory arrays (memory backend)
+            if isinstance(data, list) and len(data) > 0 and isinstance(data[0], (str, bytes, bytearray)):
+                ep_ft_array = sample_images(data)  # list of image paths
+            else:
+                ep_ft_array = sample_images_from_arrays(data)  # list of np.ndarray
             axes_to_reduce = (0, 2, 3)  # keep channel dim
             keepdims = True
         else:

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -75,15 +75,19 @@ def sample_images(image_paths: list[str]) -> np.ndarray:
 
 def sample_images_from_arrays(image_arrays: list[np.ndarray]) -> np.ndarray:
     """Return (N, C, H, W) uint8 from in-memory frames (HWC or CHW)."""
-    idxs = sample_indices(len(image_arrays)) if image_arrays else []
+    idxs = sample_indices(len(image_arrays))
     imgs: list[np.ndarray] = []
+
     for i in idxs:
-        arr = image_arrays[i]
-        if arr.dtype != np.uint8:
-            arr = arr.astype(np.uint8, copy=False)
-        img = np.transpose(arr, (2, 0, 1)) if (arr.ndim == 3 and arr.shape[-1] == 3) else arr
+        img = image_arrays[i].astype(np.uint8, copy=False)
+
+        # HWC -> CHW
+        if img.shape[-1] == 3:
+            img = np.transpose(img, (2, 0, 1))
+
         imgs.append(auto_downsample_height_width(img))
-    return np.stack(imgs, axis=0) if imgs else np.zeros((0, 3, 1, 1), dtype=np.uint8)
+
+    return np.stack(imgs, axis=0)
 
 
 def get_feature_stats(array: np.ndarray, axis: tuple, keepdims: bool) -> dict[str, np.ndarray]:
@@ -103,10 +107,10 @@ def compute_episode_stats(episode_data: dict[str, list[str] | np.ndarray], featu
             continue  # HACK: we should receive np.arrays of strings
         elif features[key]["dtype"] in ["image", "video"]:
             # data can be a list of file paths (default) or a list of in-memory arrays (memory backend)
-            if isinstance(data, list) and len(data) > 0 and isinstance(data[0], (str, bytes, bytearray)):
-                ep_ft_array = sample_images(data)  # list of image paths
-            else:
+            if isinstance(data[0], np.ndarray):
                 ep_ft_array = sample_images_from_arrays(data)  # list of np.ndarray
+            else:
+                ep_ft_array = sample_images(data)  # list of paths
             axes_to_reduce = (0, 2, 3)  # keep channel dim
             keepdims = True
         else:

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -13,10 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 
 from lerobot.datasets.utils import load_image_as_numpy
-from typing import List
 
 
 def estimate_num_samples(
@@ -73,7 +73,7 @@ def sample_images(image_paths: list[str]) -> np.ndarray:
     return images
 
 
-def sample_images_from_arrays(image_arrays: List[np.ndarray]) -> np.ndarray:
+def sample_images_from_arrays(image_arrays: list[np.ndarray]) -> np.ndarray:
     """Return (N, C, H, W) uint8 from in-memory frames (HWC or CHW)."""
     idxs = sample_indices(len(image_arrays)) if image_arrays else []
     imgs: list[np.ndarray] = []

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -812,7 +812,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
                     self.episode_buffer[key].append(arr)
                 else:
                     img_path = self._get_image_file_path(
-                        episode_index=self.episode_buffer["episode_index"], image_key=key, frame_index=frame_index
+                        episode_index=self.episode_buffer["episode_index"],
+                        image_key=key,
+                        frame_index=frame_index,
                     )
                     if frame_index == 0:
                         img_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -69,6 +69,7 @@ from lerobot.datasets.video_utils import (
     VideoFrame,
     decode_video_frames,
     encode_video_frames,
+    encode_video_frames_in_memory,
     get_safe_default_codec,
     get_video_info,
 )
@@ -457,6 +458,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.delta_indices = None
         self.batch_encoding_size = batch_encoding_size
         self.episodes_since_last_encoding = 0
+        # エンコード関連のデフォルト（読みやすさのため getattr を避ける）
+        self.video_encode_backend = "file_sequence"
+        self.video_input_format = "rgb24"
 
         # Unused attributes
         self.image_writer = None
@@ -797,14 +801,24 @@ class LeRobotDataset(torch.utils.data.Dataset):
                     f"An element of the frame is not in the features. '{key}' not in '{self.features.keys()}'."
                 )
 
-            if self.features[key]["dtype"] in ["image", "video"]:
-                img_path = self._get_image_file_path(
-                    episode_index=self.episode_buffer["episode_index"], image_key=key, frame_index=frame_index
-                )
-                if frame_index == 0:
-                    img_path.parent.mkdir(parents=True, exist_ok=True)
-                self._save_image(frame[key], img_path)
-                self.episode_buffer[key].append(str(img_path))
+            dtype = self.features[key]["dtype"]
+            if dtype in ["image", "video"]:
+                if dtype == "video" and self.video_encode_backend == "memory_pyav":
+                    arr = frame[key]
+                    if isinstance(arr, torch.Tensor):
+                        arr = arr.cpu().numpy()
+                    if arr.dtype != np.uint8:
+                        arr = arr.astype(np.uint8, copy=False)
+                    arr = np.ascontiguousarray(arr)
+                    self.episode_buffer[key].append(arr)
+                else:
+                    img_path = self._get_image_file_path(
+                        episode_index=self.episode_buffer["episode_index"], image_key=key, frame_index=frame_index
+                    )
+                    if frame_index == 0:
+                        img_path.parent.mkdir(parents=True, exist_ok=True)
+                    self._save_image(frame[key], img_path)
+                    self.episode_buffer[key].append(str(img_path))
             else:
                 self.episode_buffer[key].append(frame[key])
 
@@ -969,11 +983,24 @@ class LeRobotDataset(torch.utils.data.Dataset):
             if video_path.is_file():
                 # Skip if video is already encoded. Could be the case when resuming data recording.
                 continue
-            img_dir = self._get_image_file_path(
-                episode_index=episode_index, image_key=key, frame_index=0
-            ).parent
-            encode_video_frames(img_dir, video_path, self.fps, overwrite=True)
-            shutil.rmtree(img_dir)
+
+            frames = self.episode_buffer.get(key, []) if self.episode_buffer is not None else []
+            use_memory = len(frames) > 0 and not isinstance(frames[0], (str, bytes, bytearray))
+            if use_memory:
+                encode_video_frames_in_memory(
+                    frames,
+                    video_path,
+                    self.fps,
+                    overwrite=True,
+                    input_format=getattr(self, "video_input_format", "rgb24"),
+                )
+            else:
+                img_dir = self._get_image_file_path(
+                    episode_index=episode_index, image_key=key, frame_index=0
+                ).parent
+                encode_video_frames(img_dir, video_path, self.fps, overwrite=True)
+                if img_dir.is_dir():
+                    shutil.rmtree(img_dir)
 
         # Update video info (only needed when first episode is encoded since it reads from episode 0)
         if len(self.meta.video_keys) > 0 and episode_index == 0:
@@ -1014,6 +1041,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         image_writer_threads: int = 0,
         video_backend: str | None = None,
         batch_encoding_size: int = 1,
+        video_encode_backend: str | None = None,
+        video_input_format: str = "rgb24",
     ) -> "LeRobotDataset":
         """Create a LeRobot Dataset from scratch in order to record data."""
         obj = cls.__new__(cls)
@@ -1046,6 +1075,15 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj.delta_indices = None
         obj.episode_data_index = None
         obj.video_backend = video_backend if video_backend is not None else get_safe_default_codec()
+        obj.video_encode_backend = (
+            video_encode_backend if video_encode_backend is not None else "file_sequence"
+        )
+        obj.video_input_format = video_input_format
+        if obj.video_encode_backend == "memory_pyav" and obj.batch_encoding_size > 1:
+            logging.warning(
+                "memory_pyav backend does not support batch_encoding_size>1; falling back to file_sequence."
+            )
+            obj.video_encode_backend = "file_sequence"
         return obj
 
 

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -458,9 +458,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.delta_indices = None
         self.batch_encoding_size = batch_encoding_size
         self.episodes_since_last_encoding = 0
-        # エンコード関連のデフォルト（読みやすさのため getattr を避ける）
-        self.video_encode_backend = "file_sequence"
-        self.video_input_format = "rgb24"
+        self.frame_staging = "disk"  # or "memory"
+        self.input_pix_fmt = "rgb24"
 
         # Unused attributes
         self.image_writer = None
@@ -803,7 +802,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
 
             dtype = self.features[key]["dtype"]
             if dtype in ["image", "video"]:
-                if dtype == "video" and self.video_encode_backend == "memory_pyav":
+                if dtype == "video" and self.frame_staging == "memory":
                     arr = frame[key]
                     if isinstance(arr, torch.Tensor):
                         arr = arr.cpu().numpy()
@@ -992,7 +991,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                     video_path,
                     self.fps,
                     overwrite=True,
-                    input_format=getattr(self, "video_input_format", "rgb24"),
+                    input_format=self.input_pix_fmt,
                 )
             else:
                 img_dir = self._get_image_file_path(
@@ -1041,8 +1040,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         image_writer_threads: int = 0,
         video_backend: str | None = None,
         batch_encoding_size: int = 1,
-        video_encode_backend: str | None = None,
-        video_input_format: str = "rgb24",
+        frame_staging: str = "disk",
+        input_pix_fmt: str = "rgb24",
     ) -> "LeRobotDataset":
         """Create a LeRobot Dataset from scratch in order to record data."""
         obj = cls.__new__(cls)
@@ -1075,15 +1074,13 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj.delta_indices = None
         obj.episode_data_index = None
         obj.video_backend = video_backend if video_backend is not None else get_safe_default_codec()
-        obj.video_encode_backend = (
-            video_encode_backend if video_encode_backend is not None else "file_sequence"
-        )
-        obj.video_input_format = video_input_format
-        if obj.video_encode_backend == "memory_pyav" and obj.batch_encoding_size > 1:
+        obj.frame_staging = frame_staging
+        obj.input_pix_fmt = input_pix_fmt
+        if obj.frame_staging == "memory" and obj.batch_encoding_size > 1:
             logging.warning(
-                "memory_pyav backend does not support batch_encoding_size>1; falling back to file_sequence."
+                "'memory' frame_staging does not support batch_encoding_size>1; falling back to 'disk'."
             )
-            obj.video_encode_backend = "file_sequence"
+            obj.frame_staging = "disk"
         return obj
 
 

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -803,13 +803,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             dtype = self.features[key]["dtype"]
             if dtype in ["image", "video"]:
                 if dtype == "video" and self.frame_staging == "memory":
-                    arr = frame[key]
-                    if isinstance(arr, torch.Tensor):
-                        arr = arr.cpu().numpy()
-                    if arr.dtype != np.uint8:
-                        arr = arr.astype(np.uint8, copy=False)
-                    arr = np.ascontiguousarray(arr)
-                    self.episode_buffer[key].append(arr)
+                    self.episode_buffer[key].append(frame[key])
                 else:
                     img_path = self._get_image_file_path(
                         episode_index=self.episode_buffer["episode_index"],
@@ -986,14 +980,14 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 continue
 
             frames = self.episode_buffer.get(key, []) if self.episode_buffer is not None else []
-            use_memory = len(frames) > 0 and not isinstance(frames[0], (str, bytes, bytearray))
+            use_memory = len(frames) > 0 and isinstance(frames[0], np.ndarray)
             if use_memory:
                 encode_video_frames_in_memory(
                     frames,
                     video_path,
                     self.fps,
                     overwrite=True,
-                    input_format=self.input_pix_fmt,
+                    input_pix_fmt=self.input_pix_fmt,
                 )
             else:
                 img_dir = self._get_image_file_path(

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -18,7 +18,7 @@ import importlib
 import logging
 import shutil
 import warnings
-from collections.abc import Iterable
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
@@ -334,7 +334,7 @@ def encode_video_frames(
 
 
 def encode_video_frames_in_memory(
-    frames: Iterable[np.ndarray],
+    frames: Sequence[np.ndarray],
     video_path: Path | str,
     fps: int,
     vcodec: str = "libsvtav1",
@@ -344,7 +344,7 @@ def encode_video_frames_in_memory(
     fast_decode: int = 0,
     log_level: int | None = av.logging.ERROR,
     overwrite: bool = True,
-    input_format: str = "rgb24",
+    input_pix_fmt: str = "rgb24",
 ) -> None:
     """Encode frames already in memory without writing PNG images."""
     # Check encoder availability
@@ -358,12 +358,9 @@ def encode_video_frames_in_memory(
         )
         pix_fmt = "yuv420p"
 
-    frames_iter = iter(frames)
-    first = next(frames_iter)
-
-    if first.dtype != np.uint8:
-        first = first.astype(np.uint8, copy=False)
-    height, width = int(first.shape[0]), int(first.shape[1])
+    if not frames:
+        raise FileNotFoundError("No frames provided for in-memory encoding.")
+    height, width = int(frames[0].shape[0]), int(frames[0].shape[1])
 
     video_path = Path(video_path)
     video_path.parent.mkdir(parents=True, exist_ok=overwrite)
@@ -391,19 +388,13 @@ def encode_video_frames_in_memory(
         stream.width = width
         stream.height = height
 
-        def push(arr: np.ndarray) -> None:
-            if arr.dtype != np.uint8:
-                arr = arr.astype(np.uint8, copy=False)
-
-            arr = np.ascontiguousarray(arr)
-            frame = av.VideoFrame.from_ndarray(arr, format=input_format)
+        for frame in frames:
+            frame = frame.astype(np.uint8, copy=False)
+            frame = np.ascontiguousarray(frame)
+            frame = av.VideoFrame.from_ndarray(frame, format=input_pix_fmt)
             packet = stream.encode(frame)
             if packet:
                 output.mux(packet)
-
-        push(first)
-        for f in frames_iter:
-            push(f)
 
         # Flush the encoder
         packet = stream.encode()

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -20,7 +20,7 @@ import shutil
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Iterable
 
 import av
 import pyarrow as pa
@@ -28,6 +28,7 @@ import torch
 import torchvision
 from datasets.features.features import register_feature
 from PIL import Image
+import numpy as np
 
 
 def get_safe_default_codec():
@@ -320,6 +321,91 @@ def encode_video_frames(
 
         # Flush the encoder
         packet = output_stream.encode()
+        if packet:
+            output.mux(packet)
+
+    # Reset logging level
+    if log_level is not None:
+        av.logging.restore_default_callback()
+
+    if not video_path.exists():
+        raise OSError(f"Video encoding did not work. File not found: {video_path}.")
+
+
+def encode_video_frames_in_memory(
+    frames: Iterable[np.ndarray],
+    video_path: Path | str,
+    fps: int,
+    vcodec: str = "libsvtav1",
+    pix_fmt: str = "yuv420p",
+    g: int | None = 2,
+    crf: int | None = 30,
+    fast_decode: int = 0,
+    log_level: int | None = av.logging.ERROR,
+    overwrite: bool = True,
+    input_format: str = "rgb24",
+) -> None:
+    """Encode frames already in memory without writing PNG images."""
+    # Check encoder availability
+    if vcodec not in ["h264", "hevc", "libsvtav1"]:
+        raise ValueError(f"Unsupported video codec: {vcodec}. Supported codecs are: h264, hevc, libsvtav1.")
+
+    # Encoders/pixel formats incompatibility check
+    if (vcodec == "libsvtav1" or vcodec == "hevc") and pix_fmt == "yuv444p":
+        logging.warning(
+            f"Incompatible pixel format 'yuv444p' for codec {vcodec}, auto-selecting format 'yuv420p'"
+        )
+        pix_fmt = "yuv420p"
+
+    frames_iter = iter(frames)
+    first = next(frames_iter)
+
+    if first.dtype != np.uint8:
+        first = first.astype(np.uint8, copy=False)
+    height, width = int(first.shape[0]), int(first.shape[1])
+
+    video_path = Path(video_path)
+    video_path.parent.mkdir(parents=True, exist_ok=overwrite)
+
+    # Define video codec options
+    video_options: dict[str, str] = {}
+    if g is not None:
+        video_options["g"] = str(g)
+    if crf is not None:
+        video_options["crf"] = str(crf)
+    if fast_decode:
+        key = "svtav1-params" if vcodec == "libsvtav1" else "tune"
+        value = f"fast-decode={fast_decode}" if vcodec == "libsvtav1" else "fastdecode"
+        video_options[key] = value
+
+    # Set logging level
+    if log_level is not None:
+        # "While less efficient, it is generally preferable to modify logging with Python’s logging"
+        logging.getLogger("libav").setLevel(log_level)
+
+    # Create and open output file (overwrite by default)
+    with av.open(str(video_path), "w") as output:
+        stream = output.add_stream(vcodec, fps, options=video_options)
+        stream.pix_fmt = pix_fmt
+        stream.width = width
+        stream.height = height
+
+        def push(arr: np.ndarray) -> None:
+            if arr.dtype != np.uint8:
+                arr = arr.astype(np.uint8, copy=False)
+
+            arr = np.ascontiguousarray(arr)
+            frame = av.VideoFrame.from_ndarray(arr, format=input_format)
+            packet = stream.encode(frame)
+            if packet:
+                output.mux(packet)
+
+        push(first)
+        for f in frames_iter:
+            push(f)
+
+        # Flush the encoder
+        packet = stream.encode()
         if packet:
             output.mux(packet)
 

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -18,17 +18,18 @@ import importlib
 import logging
 import shutil
 import warnings
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, Iterable
+from typing import Any, ClassVar
 
 import av
+import numpy as np
 import pyarrow as pa
 import torch
 import torchvision
 from datasets.features.features import register_feature
 from PIL import Image
-import numpy as np
 
 
 def get_safe_default_codec():


### PR DESCRIPTION
## What this does

This PR experimentally improves the performance of the `save_episode()` function.

The `encode_episode_videos()` previously saved images as `.png` images, asynchronously loaded them as PIL images, converted them to RGB images, and created a video from the PIL images with PyAV. This process was the biggest bottleneck, accounting for approximately 56% of the total runtime (for converting 11 rosbags in my environment).

The new pipeline stores the images as `np.ndarray` in memory and directly inputs them to PyAV when `frame_staging = "memory"`. This pipeline shortcuts the above process and reduces about 50% of the total execution time.

- Execution time (main.py with `debug_data`)
    - Before: 382.902 [sec]
    - After: 195.010 [sec]

## How it was tested

Visually checked the generated videos.

hand
https://github.com/user-attachments/assets/9261391e-d0dc-4aab-8e2f-2cbe6de86648

head
https://github.com/user-attachments/assets/5f495929-62ce-4bdd-bb6c-529696323f1c

## How to checkout & try? (for the reviewer)

We can measure the execution time by running these commands in the [PR](https://github.com/airoa-org/robot_data_pipeline/pull/140)'s branch after downloading `debug_data` dataset from AWS,

```bash
uv sync --reinstall-package lerobot
uv add pyinstrument
uv run pyinstrument -r html -o profile.html -m hsr_data_converter.rosbag2lerobot.main --raw_dir {path to the debug_data directory} --out_dir ./datasets --fps 10 --robot_type hsr --conversion_type aggregate --separate_per_primitive false
```
